### PR TITLE
Support a separate audit database

### DIFF
--- a/couchdb-audit/kanso.js
+++ b/couchdb-audit/kanso.js
@@ -6,7 +6,7 @@ module.exports = {
 
   /**
    * Sets up auditing to work with the kanso db module.
-   * 
+   *
    * @name withKanso(db)
    * @param {Object} db The kanso db instance to use.
    * @api public
@@ -36,7 +36,8 @@ module.exports = {
         });
       }
     };
-    return log.init(appname, clientWrapper, dbWrapper, function(callback) {
+    // TODO: support a different audit and docs dbs
+    return log.init(appname, clientWrapper, dbWrapper, dbWrapper, function(callback) {
       session.info(function(err, result) {
         if (err) {
           return callback(err);

--- a/couchdb-audit/kanso.js
+++ b/couchdb-audit/kanso.js
@@ -2,17 +2,8 @@ var log = require('couchdb-audit/log'),
     appname = require('settings/root').name,
     session = require('session');
 
-module.exports = {
-
-  /**
-   * Sets up auditing to work with the kanso db module.
-   *
-   * @name withKanso(db)
-   * @param {Object} db The kanso db instance to use.
-   * @api public
-   */
-  withKanso: function(db) {
-    var dbWrapper = {
+var getDbWrapper = function(db) {
+  return {
       view: function(design, view, query, callback) {
         db.getView.call(db, design, view, query, callback);
       },
@@ -29,6 +20,27 @@ module.exports = {
         db.bulkSave.call(db, options.docs, options, callback);
       }
     };
+};
+
+module.exports = {
+
+  /**
+   * Sets up auditing to work with the kanso db module.
+   *
+   * @name withKanso(db)
+   * @param {Object} db The kanso db instance to use.
+   * @param {Object} auditDb Optionally the kanso db instance to use for auditing.
+   * @api public
+   */
+  withKanso: function(db, auditDb) {
+    var dbWrapper = getDbWrapper(db);
+    var auditDbWrapper;
+    if (auditDb) {
+      auditDbWrapper = getDbWrapper(auditDb);
+    } else {
+      auditDbWrapper = dbWrapper;
+    }
+
     var clientWrapper = {
       uuids: function(count, callback) {
         db.newUUID.call(db, 100, function(err, id) {
@@ -36,8 +48,8 @@ module.exports = {
         });
       }
     };
-    // TODO: support a different audit and docs dbs
-    return log.init(appname, clientWrapper, dbWrapper, dbWrapper, function(callback) {
+
+    return log.init(appname, clientWrapper, dbWrapper, auditDbWrapper, function(callback) {
       session.info(function(err, result) {
         if (err) {
           return callback(err);

--- a/couchdb-audit/node.js
+++ b/couchdb-audit/node.js
@@ -13,13 +13,19 @@ module.exports = {
    *
    * @name withFelix(felix, name)
    * @param {Object} felix The felix instance to use to persist.
+   * @param {Object} felixAudit Optionally a different felix instance to use to persist audit data
    * @param {String|Function(err, name)} name Either the authors name,
    *    or a function to retrieve the name.
    * @api public
    */
-  withFelix: function(felix, name) {
-    // FIXME: support a different audit and docs db
-    return log.init(felix.name, felix.client, felix, felix, getNameFn(name));
+  // withFelix: function(felix, felixAudit, name) {
+  withFelix: function(felix, felixAudit, name) {
+    if (arguments.length === 2) {
+      name = arguments[1];
+      felixAudit = felix;
+    }
+
+    return log.init(felix.name, felix.client, felix, felixAudit, getNameFn(name));
   },
 
   /**
@@ -29,13 +35,19 @@ module.exports = {
    * @name withNano(nano, name)
    * @param {Object} nano The nano instance to use to persist.
    * @param {String} dbName The name of the db to use.
+   * @param {String} auditDbName Optionally a different db for persisting audit data.
    * @param {String} designName The name of the design to use.
    * @param {String|Function(err, name)} authorName Either the authors name,
    *    or a function to retrieve the name.
    * @api public
    */
-  // withNano: function(nano, dbName, designName, authorName) {
   withNano: function(nano, dbName, auditDbName, designName, authorName) {
+    if (arguments.length === 4) {
+      authorName = arguments[3];
+      designName = arguments[2];
+      auditDbName = dbName;
+    }
+
     // let calls fall through- only overwrite calls that need to be audited
     var db = nano.use(dbName);
     var dbWrapper = {

--- a/couchdb-audit/node.js
+++ b/couchdb-audit/node.js
@@ -18,10 +18,9 @@ module.exports = {
    *    or a function to retrieve the name.
    * @api public
    */
-  // withFelix: function(felix, felixAudit, name) {
   withFelix: function(felix, felixAudit, name) {
     if (arguments.length === 2) {
-      name = arguments[1];
+      name = felixAudit;
       felixAudit = felix;
     }
 
@@ -43,8 +42,8 @@ module.exports = {
    */
   withNano: function(nano, dbName, auditDbName, designName, authorName) {
     if (arguments.length === 4) {
-      authorName = arguments[3];
-      designName = arguments[2];
+      authorName = designName;
+      designName = auditDbName;
       auditDbName = dbName;
     }
 

--- a/couchdb-audit/node.js
+++ b/couchdb-audit/node.js
@@ -18,7 +18,8 @@ module.exports = {
    * @api public
    */
   withFelix: function(felix, name) {
-    return log.init(felix.name, felix.client, felix, getNameFn(name));
+    // FIXME: support a different audit and docs db
+    return log.init(felix.name, felix.client, felix, felix, getNameFn(name));
   },
 
   /**
@@ -33,7 +34,8 @@ module.exports = {
    *    or a function to retrieve the name.
    * @api public
    */
-  withNano: function(nano, dbName, designName, authorName) {
+  // withNano: function(nano, dbName, designName, authorName) {
+  withNano: function(nano, dbName, auditDbName, designName, authorName) {
     // let calls fall through- only overwrite calls that need to be audited
     var db = nano.use(dbName);
     var dbWrapper = {
@@ -43,12 +45,21 @@ module.exports = {
       removeDoc: db.destroy,
       bulkDocs: db.bulk
     };
+
+    var auditDb = nano.use(auditDbName);
+    var auditDbWrapper = {
+      view: auditDb.view,
+      getDoc: auditDb.get,
+      saveDoc: auditDb.insert,
+      removeDoc: auditDb.destroy,
+      bulkDocs: auditDb.bulk
+    };
     var clientWrapper = {
       uuids: function(count, callback) {
         nano.request({ db: '_uuids', params: { count: count }}, callback);
       }
     };
-    return log.init(designName, clientWrapper, dbWrapper, getNameFn(authorName));
+    return log.init(designName, clientWrapper, dbWrapper, auditDbWrapper, getNameFn(authorName));
   }
 
 };


### PR DESCRIPTION
Allows for users to pass in a separate database to store and retrieve audit records from. The API should stay backwards compatible: users shouldn't have to specify a separate audit db if they don't want to.

Happy to smush it into one commit too if you like.